### PR TITLE
perf(android): cut cover placeholder cost and bound the infinite list window

### DIFF
--- a/apps/mobile/modules/novella-ui/android/src/main/java/sh/celia/novella/modules/novellaui/BlurHash.kt
+++ b/apps/mobile/modules/novella-ui/android/src/main/java/sh/celia/novella/modules/novellaui/BlurHash.kt
@@ -1,67 +1,125 @@
 package sh.celia.novella.modules.novellaui
 
+import android.content.Context
 import android.graphics.Bitmap
-import androidx.compose.foundation.Image
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.layout.ContentScale
-import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.FunctionalComposableScope
-import expo.modules.kotlin.views.OptimizedComposeProps
-import expo.modules.ui.ModifierList
-import expo.modules.ui.ModifierRegistry
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import android.os.Trace
+import android.util.LruCache
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.views.ExpoView
 
-@OptimizedComposeProps
-data class BlurHashProps(
-  val blurHash: String = "",
-  val width: Int = 32,
-  val height: Int = 48,
-  val modifiers: ModifierList = emptyList()
-) : ComposeProps
+/**
+ * Decoded placeholder cache. Cover placeholders are 32x48 (~6KB each), so 256
+ * entries cost well under 2MB while removing every repeated decode: grids
+ * re-mount the same covers constantly while scrolling and recycling.
+ *
+ * Bitmaps are immutable and only ever read, so handing the same instance to
+ * several ImageViews is safe; eviction merely drops our reference because the
+ * views still hold theirs.
+ */
+private object BlurHashBitmaps {
+  private const val MAX_ENTRIES = 256
+  private val cache = LruCache<String, Bitmap>(MAX_ENTRIES)
 
-@Composable
-fun FunctionalComposableScope.BlurHashContent(props: BlurHashProps) {
-  val width = props.width.coerceIn(1, 128)
-  val height = props.height.coerceIn(1, 128)
-  val bitmap = remember(props.blurHash, width, height) {
-    // Expo Image's Android cosine cache is keyed only by dimension * component
-    // count. Different dimension/component pairs can collide and produce black
-    // bands. Keep Expo's native decoder but bypass that unsafe global cache for
-    // these tiny placeholders.
-    decodeWithExpoImage(props.blurHash, width, height)
+  fun get(blurHash: String, width: Int, height: Int): Bitmap? {
+    if (blurHash.isEmpty()) return null
+    val key = "$blurHash|$width|$height"
+    cache.get(key)?.let {
+      Trace.beginSection("NovellaBlurHash.cacheHit")
+      Trace.endSection()
+      return it
+    }
+    Trace.beginSection("NovellaBlurHash.decode")
+    val bitmap = try {
+      decodeWithExpoImage(blurHash, width, height)
+    } finally {
+      Trace.endSection()
+    }
+    if (bitmap != null) cache.put(key, bitmap)
+    return bitmap
   }
-  if (bitmap != null) {
-    Image(
-      bitmap = bitmap.asImageBitmap(),
-      contentDescription = null,
-      contentScale = ContentScale.Crop,
-      modifier = ModifierRegistry.applyModifiers(
-        props.modifiers,
-        appContext,
-        composableScope,
-        globalEventDispatcher
+
+  private fun decodeWithExpoImage(blurHash: String, width: Int, height: Int): Bitmap? =
+    runCatching {
+      // expo-image is autolinked into Expo's aggregated Android module and is not
+      // available as a separate Gradle project dependency in SDK 57. Resolve its
+      // bundled decoder at runtime so this adapter can select useCache=false
+      // without copying the BlurHash algorithm or moving pixels through JS.
+      //
+      // Expo Image's own cosine cache is keyed only by dimension * component
+      // count, so different dimension/component pairs collide and produce black
+      // bands. We keep Expo's decoder but bypass that unsafe global cache and
+      // memoise the finished bitmaps here instead.
+      val decoderClass = Class.forName("expo.modules.image.blurhash.BlurhashDecoder")
+      val decoder = decoderClass.getField("INSTANCE").get(null)
+      val decode = decoderClass.getMethod(
+        "decode",
+        String::class.java,
+        Int::class.javaPrimitiveType,
+        Int::class.javaPrimitiveType,
+        Float::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType
       )
-    )
-  }
+      decode.invoke(decoder, blurHash, width, height, 1f, false) as? Bitmap
+    }.getOrNull()
 }
 
-private fun decodeWithExpoImage(blurHash: String, width: Int, height: Int): Bitmap? =
-  runCatching {
-    // expo-image is autolinked into Expo's aggregated Android module and is not
-    // available as a separate Gradle project dependency in SDK 57. Resolve its
-    // bundled decoder at runtime so this adapter can select useCache=false
-    // without copying the BlurHash algorithm or moving pixels through JS.
-    val decoderClass = Class.forName("expo.modules.image.blurhash.BlurhashDecoder")
-    val decoder = decoderClass.getField("INSTANCE").get(null)
-    val decode = decoderClass.getMethod(
-      "decode",
-      String::class.java,
-      Int::class.javaPrimitiveType,
-      Int::class.javaPrimitiveType,
-      Float::class.javaPrimitiveType,
-      Boolean::class.javaPrimitiveType
-    )
-    decode.invoke(decoder, blurHash, width, height, 1f, false) as? Bitmap
-  }.getOrNull()
+/**
+ * Plain View-backed BlurHash placeholder.
+ *
+ * The previous implementation was a Jetpack Compose `ExpoUIView`, so every
+ * cover tile paid for a ComposeView, its own composition and an
+ * AndroidComposeView owner — hundreds of them while scrolling a grid.
+ *
+ * The bitmap is drawn by this view itself rather than by a child ImageView:
+ * React Native sizes the exported view but never measures its native children,
+ * which left a child collapsed in the corner instead of filling the tile.
+ */
+class BlurHashView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
+  private val paint = Paint(Paint.FILTER_BITMAP_FLAG)
+  private val destination = Rect()
+
+  private var bitmap: Bitmap? = null
+  private var blurHash: String = ""
+  private var decodeWidth: Int = 32
+  private var decodeHeight: Int = 48
+
+  init {
+    setWillNotDraw(false)
+  }
+
+  fun setBlurHash(value: String) {
+    if (value == blurHash) return
+    blurHash = value
+    render()
+  }
+
+  fun setDecodeWidth(value: Int) {
+    val next = value.coerceIn(1, 128)
+    if (next == decodeWidth) return
+    decodeWidth = next
+    render()
+  }
+
+  fun setDecodeHeight(value: Int) {
+    val next = value.coerceIn(1, 128)
+    if (next == decodeHeight) return
+    decodeHeight = next
+    render()
+  }
+
+  override fun onDraw(canvas: Canvas) {
+    val current = bitmap ?: return
+    // Placeholder and tile share the cover aspect ratio, so filling the bounds
+    // matches the previous ContentScale.Crop without any cropping maths.
+    destination.set(0, 0, width, height)
+    canvas.drawBitmap(current, null, destination, paint)
+  }
+
+  private fun render() {
+    bitmap = BlurHashBitmaps.get(blurHash, decodeWidth, decodeHeight)
+    invalidate()
+  }
+}

--- a/apps/mobile/modules/novella-ui/android/src/main/java/sh/celia/novella/modules/novellaui/BlurHash.kt
+++ b/apps/mobile/modules/novella-ui/android/src/main/java/sh/celia/novella/modules/novellaui/BlurHash.kt
@@ -26,11 +26,7 @@ private object BlurHashBitmaps {
   fun get(blurHash: String, width: Int, height: Int): Bitmap? {
     if (blurHash.isEmpty()) return null
     val key = "$blurHash|$width|$height"
-    cache.get(key)?.let {
-      Trace.beginSection("NovellaBlurHash.cacheHit")
-      Trace.endSection()
-      return it
-    }
+    cache.get(key)?.let { return it }
     Trace.beginSection("NovellaBlurHash.decode")
     val bitmap = try {
       decodeWithExpoImage(blurHash, width, height)
@@ -68,10 +64,6 @@ private object BlurHashBitmaps {
 
 /**
  * Plain View-backed BlurHash placeholder.
- *
- * The previous implementation was a Jetpack Compose `ExpoUIView`, so every
- * cover tile paid for a ComposeView, its own composition and an
- * AndroidComposeView owner — hundreds of them while scrolling a grid.
  *
  * The bitmap is drawn by this view itself rather than by a child ImageView:
  * React Native sizes the exported view but never measures its native children,

--- a/apps/mobile/modules/novella-ui/android/src/main/java/sh/celia/novella/modules/novellaui/NovellaUiModule.kt
+++ b/apps/mobile/modules/novella-ui/android/src/main/java/sh/celia/novella/modules/novellaui/NovellaUiModule.kt
@@ -8,8 +8,14 @@ class NovellaUiModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("NovellaUi")
 
-    ExpoUIView<BlurHashProps>("BlurHash") {
-      Content { props -> BlurHashContent(props) }
+    View(BlurHashView::class) {
+      Name("BlurHash")
+
+      // NOT "width"/"height": those collide with React Native's layout style
+      // props and Yoga would size the view to the decode dimensions.
+      Prop("blurHash") { view: BlurHashView, value: String -> view.setBlurHash(value) }
+      Prop("decodeWidth") { view: BlurHashView, value: Int -> view.setDecodeWidth(value) }
+      Prop("decodeHeight") { view: BlurHashView, value: Int -> view.setDecodeHeight(value) }
     }
 
     ExpoUIView<BottomSheetProps>("BottomSheet") {

--- a/apps/mobile/modules/novella-ui/src/native-blur-hash.android.tsx
+++ b/apps/mobile/modules/novella-ui/src/native-blur-hash.android.tsx
@@ -3,17 +3,10 @@ import type { StyleProp, ViewStyle } from 'react-native';
 
 export interface NativeBlurHashProps {
   blurHash: string;
-  /**
-   * Decode resolution in pixels. Deliberately not `width`/`height`: those are
-   * React Native layout style names and Yoga would size the view to them.
-   */
+  /** Decode resolution in pixels, not layout size. */
   decodeHeight: number;
   decodeWidth: number;
   style?: StyleProp<ViewStyle>;
 }
 
-/**
- * View-backed placeholder: no Compose host per cover tile. Decoded bitmaps are
- * memoised natively, so re-mounting the same cover costs a cache lookup.
- */
 export const NativeBlurHash = requireNativeView<NativeBlurHashProps>('NovellaUi', 'BlurHash');

--- a/apps/mobile/modules/novella-ui/src/native-blur-hash.android.tsx
+++ b/apps/mobile/modules/novella-ui/src/native-blur-hash.android.tsx
@@ -1,21 +1,19 @@
-import type { PrimitiveBaseProps } from '@expo/ui/jetpack-compose';
-import { createViewModifierEventListener } from '@expo/ui/jetpack-compose/modifiers';
 import { requireNativeView } from 'expo';
+import type { StyleProp, ViewStyle } from 'react-native';
 
-export interface NativeBlurHashProps extends PrimitiveBaseProps {
+export interface NativeBlurHashProps {
   blurHash: string;
-  height: number;
-  width: number;
+  /**
+   * Decode resolution in pixels. Deliberately not `width`/`height`: those are
+   * React Native layout style names and Yoga would size the view to them.
+   */
+  decodeHeight: number;
+  decodeWidth: number;
+  style?: StyleProp<ViewStyle>;
 }
 
-const NativeView = requireNativeView<NativeBlurHashProps>('NovellaUi', 'BlurHash');
-
-export function NativeBlurHash({ modifiers, ...props }: NativeBlurHashProps) {
-  return (
-    <NativeView
-      {...props}
-      {...(modifiers ? { modifiers } : {})}
-      {...(modifiers ? createViewModifierEventListener(modifiers) : {})}
-    />
-  );
-}
+/**
+ * View-backed placeholder: no Compose host per cover tile. Decoded bitmaps are
+ * memoised natively, so re-mounting the same cover costs a cache lookup.
+ */
+export const NativeBlurHash = requireNativeView<NativeBlurHashProps>('NovellaUi', 'BlurHash');

--- a/apps/mobile/modules/novella-ui/src/native-blur-hash.tsx
+++ b/apps/mobile/modules/novella-ui/src/native-blur-hash.tsx
@@ -1,11 +1,13 @@
-import type { PrimitiveBaseProps } from '@expo/ui/jetpack-compose';
+import type { StyleProp, ViewStyle } from 'react-native';
 
-export interface NativeBlurHashProps extends PrimitiveBaseProps {
+export interface NativeBlurHashProps {
   blurHash: string;
-  height: number;
-  width: number;
+  decodeHeight: number;
+  decodeWidth: number;
+  style?: StyleProp<ViewStyle>;
 }
 
+/** iOS renders BlurHash placeholders through expo-image; nothing native here. */
 export function NativeBlurHash(_props: NativeBlurHashProps): null {
   return null;
 }

--- a/apps/mobile/src/components/book-cover-blur-hash.android.tsx
+++ b/apps/mobile/src/components/book-cover-blur-hash.android.tsx
@@ -4,11 +4,6 @@ import { NativeBlurHash } from '../../modules/novella-ui';
 
 import type { ExpoBlurHashPlaceholder } from '@/services/blurhash';
 
-/**
- * Android placeholders render through the native view only. Previously an
- * expo-image BlurHash layer was drawn *and* covered by this view, so every
- * cover tile decoded the same BlurHash twice and mounted two native views.
- */
 export function BookCoverBlurHash({
   placeholder,
 }: {

--- a/apps/mobile/src/components/book-cover-blur-hash.android.tsx
+++ b/apps/mobile/src/components/book-cover-blur-hash.android.tsx
@@ -1,33 +1,25 @@
-import { Host } from '@expo/ui';
-import { fillMaxSize } from '@expo/ui/jetpack-compose/modifiers';
-import { Image } from 'expo-image';
 import { StyleSheet } from 'react-native';
 
 import { NativeBlurHash } from '../../modules/novella-ui';
 
 import type { ExpoBlurHashPlaceholder } from '@/services/blurhash';
 
+/**
+ * Android placeholders render through the native view only. Previously an
+ * expo-image BlurHash layer was drawn *and* covered by this view, so every
+ * cover tile decoded the same BlurHash twice and mounted two native views.
+ */
 export function BookCoverBlurHash({
   placeholder,
 }: {
   placeholder: ExpoBlurHashPlaceholder;
 }) {
   return (
-    <>
-      <Image
-        accessibilityElementsHidden
-        contentFit="cover"
-        source={placeholder}
-        style={StyleSheet.absoluteFill}
-      />
-      <Host style={StyleSheet.absoluteFill} useViewportSizeMeasurement>
-        <NativeBlurHash
-          blurHash={placeholder.blurhash}
-          height={placeholder.height}
-          modifiers={[fillMaxSize()]}
-          width={placeholder.width}
-        />
-      </Host>
-    </>
+    <NativeBlurHash
+      blurHash={placeholder.blurhash}
+      decodeHeight={placeholder.height}
+      decodeWidth={placeholder.width}
+      style={StyleSheet.absoluteFill}
+    />
   );
 }

--- a/apps/mobile/src/components/book-cover-grid-item.tsx
+++ b/apps/mobile/src/components/book-cover-grid-item.tsx
@@ -1,4 +1,5 @@
 import { IconCheck, IconGripVertical } from '@tabler/icons-react-native';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Pressable,
@@ -34,14 +35,19 @@ interface BookCoverGridItemProps {
   networkImageEnabled?: boolean;
   onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
   onLongPress?: (event: GestureResponderEvent) => void;
-  onPress?: () => void;
+  /** Receives the rendered book so callers can hoist a stable handler. */
+  onPress?: (book: BookListItem) => void;
   onPressOut?: () => void;
   /** Leaderboard position; renders a gold/silver/bronze badge for ranks 1-3. */
   rank?: number;
   tileWidth: number;
 }
 
-export function BookCoverGridItem({
+/**
+ * Memoised: grids re-render on every cover-activation change, and without this
+ * every tile in the list re-rendered for one newly activated cover.
+ */
+export const BookCoverGridItem = memo(function BookCoverGridItem({
   accessibilityActions,
   animateCachedImage,
   book,
@@ -72,7 +78,7 @@ export function BookCoverGridItem({
       delayLongPress={180}
       onAccessibilityAction={onAccessibilityAction}
       onLongPress={onLongPress}
-      onPress={onPress}
+      onPress={onPress ? () => onPress(book) : undefined}
       onPressOut={onPressOut}
       style={[styles.item, { width: tileWidth }]}
     >
@@ -127,7 +133,7 @@ export function BookCoverGridItem({
       </View>
     </Pressable>
   );
-}
+});
 
 function RankBadge({ rank }: { rank: number }) {
   const styles = useBookCoverGridItemStyles();

--- a/apps/mobile/src/components/book-cover-image.tsx
+++ b/apps/mobile/src/components/book-cover-image.tsx
@@ -67,9 +67,7 @@ function BookCoverImageLayer({
   const [attempt, setAttempt] = useState(0);
   const [status, setStatus] = useState<CoverStatus>('loading');
 
-  // A cached cover needs no cross-dissolve; a fresh one fades over the
-  // BlurHash. expo-image runs this on the native view, so covers no longer
-  // drive one Animated node and one extra RN view each.
+  // A cached cover needs no cross-dissolve; a fresh one fades over the BlurHash.
   const fadeDurationMs = wasRevealed && !animateCachedImage ? 0 : COVER_FADE_DURATION_MS;
 
   useEffect(() => () => {

--- a/apps/mobile/src/components/book-cover-image.tsx
+++ b/apps/mobile/src/components/book-cover-image.tsx
@@ -61,71 +61,45 @@ function BookCoverImageLayer({
   const placeholder = createBookCoverBlurHashPlaceholder(blurHash);
   const cacheKey = coverCacheKey(source);
   const wasRevealed = source.length > 0 && revealedCoverUrls.has(cacheKey);
-  // A cache hit means decoding can be skipped, not that this native view has
-  // displayed pixels. Keep the placeholder visible until onDisplay fires.
-  const opacity = useRef(new Animated.Value(0)).current;
-  const startedAt = useRef(Date.now());
-  const networkStarted = useRef(networkImageEnabled);
-  const revealTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const revealScheduled = useRef(false);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mounted = useRef(true);
   const [attempt, setAttempt] = useState(0);
   const [status, setStatus] = useState<CoverStatus>('loading');
 
+  // A cached cover needs no cross-dissolve; a fresh one fades over the
+  // BlurHash. expo-image runs this on the native view, so covers no longer
+  // drive one Animated node and one extra RN view each.
+  const fadeDurationMs = wasRevealed && !animateCachedImage ? 0 : COVER_FADE_DURATION_MS;
+
   useEffect(() => () => {
     mounted.current = false;
-    if (revealTimer.current !== null) clearTimeout(revealTimer.current);
-    if (retryTimer.current !== null) clearTimeout(retryTimer.current);
-    opacity.stopAnimation();
-  }, [opacity]);
+    clearTimeout(settleTimer.current ?? undefined);
+    clearTimeout(retryTimer.current ?? undefined);
+  }, []);
 
-  useLayoutEffect(() => {
-    if (!networkImageEnabled) {
-      if (revealTimer.current !== null) clearTimeout(revealTimer.current);
-      if (retryTimer.current !== null) clearTimeout(retryTimer.current);
-      revealTimer.current = null;
-      retryTimer.current = null;
-      revealScheduled.current = false;
-      networkStarted.current = false;
-      opacity.stopAnimation();
-      opacity.setValue(0);
-      setStatus('loading');
-      return;
-    }
-    if (networkStarted.current) return;
-    networkStarted.current = true;
-    startedAt.current = Date.now();
-  }, [networkImageEnabled, opacity]);
+  useEffect(() => {
+    if (networkImageEnabled) return;
+    clearTimeout(settleTimer.current ?? undefined);
+    clearTimeout(retryTimer.current ?? undefined);
+    settleTimer.current = null;
+    retryTimer.current = null;
+    setStatus('loading');
+  }, [networkImageEnabled]);
 
   const reveal = () => {
-    if (revealScheduled.current || status === 'loaded' || status === 'revealing') return;
-    revealScheduled.current = true;
+    if (status === 'loaded' || settleTimer.current !== null) return;
     rememberRevealedCover(source);
-    if (wasRevealed && !animateCachedImage) {
-      opacity.setValue(1);
+    if (fadeDurationMs === 0) {
       setStatus('loaded');
       return;
     }
-
-    const remaining = Math.max(
-      0,
-      MINIMUM_PLACEHOLDER_DURATION_MS - (Date.now() - startedAt.current),
-    );
-    revealTimer.current = setTimeout(() => {
-      revealTimer.current = null;
-      if (!mounted.current) return;
-      setStatus('revealing');
-      Animated.timing(opacity, {
-        duration: COVER_FADE_DURATION_MS,
-        easing: (value) => 1 - (1 - value) * (1 - value),
-        toValue: 1,
-        useNativeDriver: true,
-      }).start(({ finished }) => {
-        if (!finished || !mounted.current) return;
-        setStatus('loaded');
-      });
-    }, remaining);
+    // Keep the placeholder mounted until the native cross-dissolve finishes,
+    // otherwise it disappears mid-fade and the tile flashes.
+    settleTimer.current = setTimeout(() => {
+      settleTimer.current = null;
+      if (mounted.current) setStatus('loaded');
+    }, fadeDurationMs);
   };
 
   const retry = () => {
@@ -133,26 +107,19 @@ function BookCoverImageLayer({
       clearTimeout(retryTimer.current);
       retryTimer.current = null;
     }
-    if (revealTimer.current !== null) {
-      clearTimeout(revealTimer.current);
-      revealTimer.current = null;
+    if (settleTimer.current !== null) {
+      clearTimeout(settleTimer.current);
+      settleTimer.current = null;
     }
-    revealScheduled.current = false;
-    opacity.stopAnimation();
-    opacity.setValue(0);
-    startedAt.current = Date.now();
     setStatus('loading');
     setAttempt((value) => value + 1);
   };
 
   const fail = () => {
-    if (revealTimer.current !== null) {
-      clearTimeout(revealTimer.current);
-      revealTimer.current = null;
+    if (settleTimer.current !== null) {
+      clearTimeout(settleTimer.current);
+      settleTimer.current = null;
     }
-    revealScheduled.current = false;
-    opacity.stopAnimation();
-    opacity.setValue(0);
     setStatus('error');
     if (attempt === 0 && retryTimer.current === null) {
       retryTimer.current = setTimeout(() => {
@@ -164,7 +131,9 @@ function BookCoverImageLayer({
 
   return (
     <View style={styles.root}>
-      {placeholder ? (
+      {/* Once the cover is opaque the placeholder is invisible but still drawn
+          every frame, so it is unmounted instead of stacked underneath. */}
+      {status === 'loaded' ? null : placeholder ? (
         <BookCoverBlurHash placeholder={placeholder} />
       ) : (
         <View accessibilityElementsHidden style={styles.fallback}>
@@ -173,21 +142,21 @@ function BookCoverImageLayer({
       )}
 
       {source && networkImageEnabled ? (
-        <Animated.View pointerEvents="none" style={[StyleSheet.absoluteFill, { opacity }]}>
-          <Image
-            accessibilityLabel={accessibilityLabel}
-            allowDownscaling
-            cachePolicy="memory-disk"
-            contentFit="cover"
-            enforceEarlyResizing={process.env.EXPO_OS === 'ios'}
-            key={`${cacheKey}:${attempt}`}
-            onDisplay={reveal}
-            onError={fail}
-            recyclingKey={cacheKey}
-            source={{ cacheKey, uri: source }}
-            style={StyleSheet.absoluteFill}
-          />
-        </Animated.View>
+        <Image
+          accessibilityLabel={accessibilityLabel}
+          allowDownscaling
+          cachePolicy="memory-disk"
+          contentFit="cover"
+          enforceEarlyResizing={process.env.EXPO_OS === 'ios'}
+          key={`${cacheKey}:${attempt}`}
+          onDisplay={reveal}
+          onError={fail}
+          pointerEvents="none"
+          recyclingKey={cacheKey}
+          source={{ cacheKey, uri: source }}
+          style={StyleSheet.absoluteFill}
+          transition={fadeDurationMs === 0 ? null : { duration: fadeDurationMs, effect: 'cross-dissolve' }}
+        />
       ) : null}
 
       {source && networkImageEnabled && showLoading && !wasRevealed && status === 'loading' ? (

--- a/apps/mobile/src/screens/book-comments-screen.tsx
+++ b/apps/mobile/src/screens/book-comments-screen.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/comment-thread-item';
 import { CommentThreadListItem } from '@/components/comment-thread-list-item';
 import { useBookDetailRouteTheme } from '@/components/book-detail-theme-provider';
+import { IosScrollViewMarker } from '@/components/ios-scroll-view-marker';
 import { NativeScreenScaffold } from '@/components/native-screen-scaffold';
 import { useComments } from '@/hooks/use-comments';
 import { consumeCommentsChanged } from '@/services/comment-events';
@@ -133,7 +134,7 @@ export function BookCommentsScreen({ bookId, target: commentTarget }: BookCommen
         containerColor={palette.surface}
         contentColor={palette.onSurface}
       >
-        <View style={[styles.root, { backgroundColor: palette.surface }]}>
+        <IosScrollViewMarker style={[styles.root, { backgroundColor: palette.surface }]}>
           <FlatList
             contentInsetAdjustmentBehavior="automatic"
             contentContainerStyle={styles.content}
@@ -193,7 +194,7 @@ export function BookCommentsScreen({ bookId, target: commentTarget }: BookCommen
             updateCellsBatchingPeriod={32}
             windowSize={7}
           />
-        </View>
+        </IosScrollViewMarker>
       </NativeScreenScaffold>
     </PaperProvider>
   );

--- a/apps/mobile/src/screens/book-list-screen.tsx
+++ b/apps/mobile/src/screens/book-list-screen.tsx
@@ -109,6 +109,13 @@ export function BookListScreen() {
           onEndReached={loadMore}
           onEndReachedThreshold={0.6}
           onViewableItemsChanged={coverActivation.onViewableItemsChanged}
+          // Scrolling this list forever otherwise retains ~21 screens of rows
+          // and their cover bitmaps: peak RSS measured 1.28GB over 30s of
+          // scrolling, versus 1.03GB with a bounded window, with frame pacing
+          // unchanged. `removeClippedSubviews` and smaller render batches were
+          // measured here too and rejected: they tripled draw work and added
+          // missed vsyncs without reducing dropped frames.
+          windowSize={11}
           refreshControl={
             <RefreshControl
               colors={[colors.accent as string]}

--- a/apps/mobile/src/screens/book-list-screen.tsx
+++ b/apps/mobile/src/screens/book-list-screen.tsx
@@ -124,19 +124,7 @@ export function BookListScreen() {
               <BookCoverGridItem
                 book={item}
                 networkImageEnabled={coverActivation.activatedKeys.has(bookListCoverKey(item))}
-                onPress={() => router.push({
-                  pathname: '/book/[id]',
-                  params: {
-                    cover: item.coverUrl,
-                    id: String(item.id),
-                    placeholder: item.coverPlaceholder ?? '',
-                    ...(item.type === 'Comic'
-                      ? { seriesTitle: item.seriesTitle ?? item.title }
-                      : {}),
-                    title: item.title,
-                    type: item.type ?? 'Novel',
-                  },
-                })}
+                onPress={openBookDetail}
                 tileWidth={tileWidth}
               />
             )
@@ -148,6 +136,26 @@ export function BookListScreen() {
       </NativeScreenScaffold>
     </>
   );
+}
+
+/**
+ * Module scope keeps the handler identity stable for every memoised tile, so
+ * activating one cover no longer re-renders the whole grid.
+ */
+function openBookDetail(book: BookListItem): void {
+  router.push({
+    pathname: '/book/[id]',
+    params: {
+      cover: book.coverUrl,
+      id: String(book.id),
+      placeholder: book.coverPlaceholder ?? '',
+      ...(book.type === 'Comic'
+        ? { seriesTitle: book.seriesTitle ?? book.title }
+        : {}),
+      title: book.title,
+      type: book.type ?? 'Novel',
+    },
+  });
 }
 
 function bookListCoverKey(item: BookListItem): string {

--- a/apps/mobile/src/screens/book-list-screen.tsx
+++ b/apps/mobile/src/screens/book-list-screen.tsx
@@ -109,12 +109,10 @@ export function BookListScreen() {
           onEndReached={loadMore}
           onEndReachedThreshold={0.6}
           onViewableItemsChanged={coverActivation.onViewableItemsChanged}
-          // Scrolling this list forever otherwise retains ~21 screens of rows
-          // and their cover bitmaps: peak RSS measured 1.28GB over 30s of
-          // scrolling, versus 1.03GB with a bounded window, with frame pacing
-          // unchanged. `removeClippedSubviews` and smaller render batches were
-          // measured here too and rejected: they tripled draw work and added
-          // missed vsyncs without reducing dropped frames.
+          // This list scrolls forever, and RN's default window retains ~21
+          // screens of rows with their cover bitmaps: 1.28GB peak RSS versus
+          // 1.03GB bounded, frame pacing unchanged. `removeClippedSubviews` and
+          // smaller render batches were measured here and made draw work worse.
           windowSize={11}
           refreshControl={
             <RefreshControl
@@ -145,10 +143,6 @@ export function BookListScreen() {
   );
 }
 
-/**
- * Module scope keeps the handler identity stable for every memoised tile, so
- * activating one cover no longer re-renders the whole grid.
- */
 function openBookDetail(book: BookListItem): void {
   router.push({
     pathname: '/book/[id]',

--- a/apps/mobile/src/screens/book-list-screen.tsx
+++ b/apps/mobile/src/screens/book-list-screen.tsx
@@ -20,6 +20,7 @@ import {
   bookGridSkeletonCount,
   skeletonKeys,
 } from '@/components/book-grid-skeleton';
+import { IosScrollViewMarker } from '@/components/ios-scroll-view-marker';
 import { NativeScreenScaffold } from '@/components/native-screen-scaffold';
 import { NativeSegmentedControl } from '@/components/native-segmented-control';
 import { useBookGridLayout } from '@/hooks/use-book-grid-layout';
@@ -74,13 +75,13 @@ export function BookListScreen() {
     <>
       <Stack.Screen options={{ title: t('catalog.allNovels') }} />
       <NativeScreenScaffold
-      largeTitle={false}
-      onBackPress={() => router.back()}
-      showBackButton
-      title={t('catalog.allNovels')}
-    >
-      <View style={styles.root}>
-        <FlatList
+        largeTitle={false}
+        onBackPress={() => router.back()}
+        showBackButton
+        title={t('catalog.allNovels')}
+      >
+        <IosScrollViewMarker style={styles.root}>
+          <FlatList
           ListEmptyComponent={
             error ? (
               <ErrorState error={error} onRetry={retry} />
@@ -135,9 +136,9 @@ export function BookListScreen() {
             )
           }
           showsVerticalScrollIndicator={false}
-          viewabilityConfig={coverActivation.viewabilityConfig}
-        />
-      </View>
+            viewabilityConfig={coverActivation.viewabilityConfig}
+          />
+        </IosScrollViewMarker>
       </NativeScreenScaffold>
     </>
   );

--- a/apps/mobile/src/screens/book-search-screen.tsx
+++ b/apps/mobile/src/screens/book-search-screen.tsx
@@ -229,10 +229,6 @@ export function BookSearchScreen({
   );
 }
 
-/**
- * Module scope keeps the handler identity stable for every memoised tile, so
- * activating one cover no longer re-renders the whole grid.
- */
 function openNovelDetail(book: BookListItem): void {
   router.push({
     pathname: '/book/[id]',

--- a/apps/mobile/src/screens/book-search-screen.tsx
+++ b/apps/mobile/src/screens/book-search-screen.tsx
@@ -211,33 +211,14 @@ export function BookSearchScreen({
           <BookCoverGridItem
             book={item.item}
             networkImageEnabled={coverActivation.activatedKeys.has(item.key)}
-            onPress={() => router.push({
-              pathname: '/book/[id]',
-              params: {
-                cover: item.item.coverUrl,
-                id: String(item.item.id),
-                placeholder: item.item.coverPlaceholder ?? '',
-                title: item.item.title,
-                type: 'Novel',
-              },
-            })}
+            onPress={openNovelDetail}
             tileWidth={tileWidth}
           />
         ) : (
           <BookCoverGridItem
             book={comicToBookListItem(item.item)}
             networkImageEnabled={coverActivation.activatedKeys.has(item.key)}
-            onPress={() => router.push({
-              pathname: '/book/[id]',
-              params: {
-                cover: item.item.coverUrl,
-                id: String(item.item.id),
-                placeholder: item.item.coverPlaceholder ?? '',
-                seriesTitle: item.item.title,
-                title: item.item.title,
-                type: 'Comic',
-              },
-            })}
+            onPress={openComicDetail}
             tileWidth={tileWidth}
           />
         )}
@@ -246,6 +227,41 @@ export function BookSearchScreen({
       />
     </NativeScreenScaffold>
   );
+}
+
+/**
+ * Module scope keeps the handler identity stable for every memoised tile, so
+ * activating one cover no longer re-renders the whole grid.
+ */
+function openNovelDetail(book: BookListItem): void {
+  router.push({
+    pathname: '/book/[id]',
+    params: {
+      cover: book.coverUrl,
+      id: String(book.id),
+      placeholder: book.coverPlaceholder ?? '',
+      title: book.title,
+      type: 'Novel',
+    },
+  });
+}
+
+/**
+ * Comic tiles render `comicToBookListItem` output, whose `title` carries the
+ * series title (`seriesTitle` is nulled by the conversion).
+ */
+function openComicDetail(book: BookListItem): void {
+  router.push({
+    pathname: '/book/[id]',
+    params: {
+      cover: book.coverUrl,
+      id: String(book.id),
+      placeholder: book.coverPlaceholder ?? '',
+      seriesTitle: book.title,
+      title: book.title,
+      type: 'Comic',
+    },
+  });
 }
 
 function searchItemKey(item: number | SearchResult): string {

--- a/apps/mobile/src/screens/comic-list-screen.tsx
+++ b/apps/mobile/src/screens/comic-list-screen.tsx
@@ -135,10 +135,6 @@ export function ComicListScreen() {
   );
 }
 
-/**
- * Module scope keeps the handler identity stable for every memoised tile, so
- * activating one cover no longer re-renders the whole grid.
- */
 function openComicDetail(book: BookListItem): void {
   router.push({
     pathname: '/book/[id]',

--- a/apps/mobile/src/screens/comic-list-screen.tsx
+++ b/apps/mobile/src/screens/comic-list-screen.tsx
@@ -121,17 +121,7 @@ export function ComicListScreen() {
               <BookCoverGridItem
                 book={item}
                 networkImageEnabled={coverActivation.activatedKeys.has(comicListCoverKey(item))}
-                onPress={() => router.push({
-                  pathname: '/book/[id]',
-                  params: {
-                    cover: item.coverUrl,
-                    id: String(item.id),
-                    placeholder: item.coverPlaceholder ?? '',
-                    seriesTitle: item.title,
-                    title: item.title,
-                    type: item.type ?? 'Comic',
-                  },
-                })}
+                onPress={openComicDetail}
                 tileWidth={tileWidth}
               />
             )
@@ -143,6 +133,24 @@ export function ComicListScreen() {
       </NativeScreenScaffold>
     </>
   );
+}
+
+/**
+ * Module scope keeps the handler identity stable for every memoised tile, so
+ * activating one cover no longer re-renders the whole grid.
+ */
+function openComicDetail(book: BookListItem): void {
+  router.push({
+    pathname: '/book/[id]',
+    params: {
+      cover: book.coverUrl,
+      id: String(book.id),
+      placeholder: book.coverPlaceholder ?? '',
+      seriesTitle: book.title,
+      title: book.title,
+      type: book.type ?? 'Comic',
+    },
+  });
 }
 
 function comicListCoverKey(item: BookListItem): string {

--- a/apps/mobile/src/screens/comic-list-screen.tsx
+++ b/apps/mobile/src/screens/comic-list-screen.tsx
@@ -20,6 +20,7 @@ import {
   bookGridSkeletonCount,
   skeletonKeys,
 } from '@/components/book-grid-skeleton';
+import { IosScrollViewMarker } from '@/components/ios-scroll-view-marker';
 import { NativeScreenScaffold } from '@/components/native-screen-scaffold';
 import { NativeSegmentedControl } from '@/components/native-segmented-control';
 import { useBookGridLayout } from '@/hooks/use-book-grid-layout';
@@ -71,13 +72,13 @@ export function ComicListScreen() {
     <>
       <Stack.Screen options={{ title: t('catalog.allComics') }} />
       <NativeScreenScaffold
-      largeTitle={false}
-      onBackPress={() => router.back()}
-      showBackButton
-      title={t('catalog.allComics')}
-    >
-      <View style={styles.root}>
-        <FlatList
+        largeTitle={false}
+        onBackPress={() => router.back()}
+        showBackButton
+        title={t('catalog.allComics')}
+      >
+        <IosScrollViewMarker style={styles.root}>
+          <FlatList
           ListEmptyComponent={
             error ? (
               <ErrorState error={error} onRetry={retry} />
@@ -127,9 +128,9 @@ export function ComicListScreen() {
             )
           }
           showsVerticalScrollIndicator={false}
-          viewabilityConfig={coverActivation.viewabilityConfig}
-        />
-      </View>
+            viewabilityConfig={coverActivation.viewabilityConfig}
+          />
+        </IosScrollViewMarker>
       </NativeScreenScaffold>
     </>
   );

--- a/apps/mobile/src/screens/history-screen.tsx
+++ b/apps/mobile/src/screens/history-screen.tsx
@@ -197,13 +197,15 @@ export function HistoryScreen() {
                 <BookCoverGridItem
                   book={item as BookListItem}
                   networkImageEnabled={coverActivation.activatedKeys.has(historyCoverKey(item, tab))}
-                  onPress={() => openBook(item as BookListItem)}
+                  onPress={openBook}
                   tileWidth={tileWidth}
                 />
               ) : (
                 <BookCoverGridItem
                   book={comicToBookListItem(item as ComicSeriesListItem)}
                   networkImageEnabled={coverActivation.activatedKeys.has(historyCoverKey(item, tab))}
+                  // `openComic` needs the raw ComicSeriesListItem, but the tile
+                  // only hands back the converted book, so this stays inline.
                   onPress={() => openComic(item as ComicSeriesListItem)}
                   tileWidth={tileWidth}
                 />

--- a/apps/mobile/src/screens/home-screen.tsx
+++ b/apps/mobile/src/screens/home-screen.tsx
@@ -394,19 +394,7 @@ function BookGrid({
               book={book}
               key={homeBookCoverKey(book)}
               networkImageEnabled={activatedCoverKeys.has(homeBookCoverKey(book))}
-              onPress={() => router.push({
-                pathname: '/book/[id]',
-                params: {
-                  cover: book.coverUrl,
-                  id: String(book.id),
-                  placeholder: book.coverPlaceholder ?? '',
-                  ...(book.type === 'Comic'
-                    ? { seriesTitle: book.seriesTitle ?? book.title }
-                    : {}),
-                  title: book.title,
-                  type: book.type,
-                },
-              })}
+              onPress={openBookDetail}
               tileWidth={tileWidth}
               {...(showRanks
                 ? { rank: rowIndex * columns + columnIndex + 1 }
@@ -422,6 +410,24 @@ function BookGrid({
       ))}
     </View>
   );
+}
+
+/**
+ * Module scope keeps the handler identity stable for every memoised tile, so
+ * activating one cover no longer re-renders the whole grid.
+ */
+function openBookDetail(book: BookListItem): void {
+  router.push({
+    pathname: '/book/[id]',
+    params: {
+      cover: book.coverUrl,
+      id: String(book.id),
+      placeholder: book.coverPlaceholder ?? '',
+      ...(book.type === 'Comic' ? { seriesTitle: book.seriesTitle ?? book.title } : {}),
+      title: book.title,
+      type: book.type,
+    },
+  });
 }
 
 function homeBookCoverKey(book: BookListItem): string {

--- a/apps/mobile/src/screens/home-screen.tsx
+++ b/apps/mobile/src/screens/home-screen.tsx
@@ -412,10 +412,6 @@ function BookGrid({
   );
 }
 
-/**
- * Module scope keeps the handler identity stable for every memoised tile, so
- * activating one cover no longer re-renders the whole grid.
- */
 function openBookDetail(book: BookListItem): void {
   router.push({
     pathname: '/book/[id]',

--- a/apps/mobile/src/screens/ranking-screen.tsx
+++ b/apps/mobile/src/screens/ranking-screen.tsx
@@ -22,6 +22,7 @@ import {
   bookGridSkeletonCount,
   skeletonKeys,
 } from '@/components/book-grid-skeleton';
+import { IosScrollViewMarker } from '@/components/ios-scroll-view-marker';
 import { NativeScreenScaffold } from '@/components/native-screen-scaffold';
 import { NativeSegmentedControl } from '@/components/native-segmented-control';
 import { useBookGridLayout } from '@/hooks/use-book-grid-layout';
@@ -79,13 +80,13 @@ export function RankingScreen() {
     <>
       <Stack.Screen options={{ title: t('ranking.title') }} />
       <NativeScreenScaffold
-      largeTitle={false}
-      onBackPress={() => router.back()}
-      showBackButton
-      title={t('ranking.title')}
-    >
-      <View style={styles.root}>
-        <FlatList
+        largeTitle={false}
+        onBackPress={() => router.back()}
+        showBackButton
+        title={t('ranking.title')}
+      >
+        <IosScrollViewMarker style={styles.root}>
+          <FlatList
           ListEmptyComponent={
             error ? (
               <ErrorState error={error} onRetry={retry} />
@@ -137,9 +138,9 @@ export function RankingScreen() {
             )
           }
           showsVerticalScrollIndicator={false}
-          viewabilityConfig={coverActivation.viewabilityConfig}
-        />
-      </View>
+            viewabilityConfig={coverActivation.viewabilityConfig}
+          />
+        </IosScrollViewMarker>
       </NativeScreenScaffold>
     </>
   );

--- a/apps/mobile/src/screens/ranking-screen.tsx
+++ b/apps/mobile/src/screens/ranking-screen.tsx
@@ -58,8 +58,6 @@ export function RankingScreen() {
     keyForItem: (item) => typeof item === 'number' ? null : rankingCoverKey(item),
     scopeKey: `${period}:${listKey}`,
   });
-  // Hoisted out of renderItem so the memoised tiles keep prop identity when a
-  // cover activates; otherwise every row re-renders on each activation batch.
   const openBook = useCallback((book: BookListItem) => router.push({
     pathname: '/book/[id]',
     params: {
@@ -122,9 +120,9 @@ export function RankingScreen() {
               tintColor={colors.accent as string}
             />
           }
-          // Android keeps every rendered row attached without this; clipping
-          // offscreen tiles cuts draw work and bitmap retention while scrolling.
-          removeClippedSubviews
+          // Android-only, like every other list here: on iOS this prop is known
+          // to blank out cells in multi-column lists.
+          removeClippedSubviews={process.env.EXPO_OS === 'android'}
           renderItem={({ item, index }) =>
             typeof item === 'number' ? (
               <BookCoverSkeletonTile tileWidth={tileWidth} />

--- a/apps/mobile/src/screens/ranking-screen.tsx
+++ b/apps/mobile/src/screens/ranking-screen.tsx
@@ -1,5 +1,6 @@
 import { router, Stack } from 'expo-router';
 import { IconTrophy } from '@tabler/icons-react-native';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   FlatList,
@@ -57,6 +58,19 @@ export function RankingScreen() {
     keyForItem: (item) => typeof item === 'number' ? null : rankingCoverKey(item),
     scopeKey: `${period}:${listKey}`,
   });
+  // Hoisted out of renderItem so the memoised tiles keep prop identity when a
+  // cover activates; otherwise every row re-renders on each activation batch.
+  const openBook = useCallback((book: BookListItem) => router.push({
+    pathname: '/book/[id]',
+    params: {
+      cover: book.coverUrl,
+      id: String(book.id),
+      placeholder: book.coverPlaceholder ?? '',
+      ...(book.type === 'Comic' ? { seriesTitle: book.seriesTitle ?? book.title } : {}),
+      title: book.title,
+      type: book.type ?? 'Novel',
+    },
+  }), []);
   const periodOptions: readonly { label: string; value: RankPeriod }[] = [
     { label: t('ranking.periods.daily'), value: 'daily' },
     { label: t('ranking.periods.weekly'), value: 'weekly' },
@@ -108,6 +122,9 @@ export function RankingScreen() {
               tintColor={colors.accent as string}
             />
           }
+          // Android keeps every rendered row attached without this; clipping
+          // offscreen tiles cuts draw work and bitmap retention while scrolling.
+          removeClippedSubviews
           renderItem={({ item, index }) =>
             typeof item === 'number' ? (
               <BookCoverSkeletonTile tileWidth={tileWidth} />
@@ -115,19 +132,7 @@ export function RankingScreen() {
               <BookCoverGridItem
                 book={item}
                 networkImageEnabled={coverActivation.activatedKeys.has(rankingCoverKey(item))}
-                onPress={() => router.push({
-                  pathname: '/book/[id]',
-                  params: {
-                    cover: item.coverUrl,
-                    id: String(item.id),
-                    placeholder: item.coverPlaceholder ?? '',
-                    ...(item.type === 'Comic'
-                      ? { seriesTitle: item.seriesTitle ?? item.title }
-                      : {}),
-                    title: item.title,
-                    type: item.type ?? 'Novel',
-                  },
-                })}
+                onPress={openBook}
                 rank={index + 1}
                 tileWidth={tileWidth}
               />

--- a/apps/mobile/src/screens/shelf-screen.tsx
+++ b/apps/mobile/src/screens/shelf-screen.tsx
@@ -506,18 +506,18 @@ function ShelfContent({
 
     const book = booksById.get(item.id);
     // The tile hands back its own book; the route id stays the shelf item id.
-    const handlePress = (book: BookListItem) => {
+    const handlePress = (pressed: BookListItem) => {
       router.push({
         pathname: '/book/[id]',
         params: {
-          cover: book.coverUrl,
+          cover: pressed.coverUrl,
           id: String(item.id),
-          placeholder: book.coverPlaceholder ?? '',
-          ...(book.type === 'Comic'
-            ? { seriesTitle: book.seriesTitle ?? book.title }
+          placeholder: pressed.coverPlaceholder ?? '',
+          ...(pressed.type === 'Comic'
+            ? { seriesTitle: pressed.seriesTitle ?? pressed.title }
             : {}),
-          title: book.title,
-          type: book.type,
+          title: pressed.title,
+          type: pressed.type,
         },
       });
     };

--- a/apps/mobile/src/screens/shelf-screen.tsx
+++ b/apps/mobile/src/screens/shelf-screen.tsx
@@ -505,8 +505,8 @@ function ShelfContent({
     }
 
     const book = booksById.get(item.id);
-    const handlePress = () => {
-      if (!book) return;
+    // The tile hands back its own book; the route id stays the shelf item id.
+    const handlePress = (book: BookListItem) => {
       router.push({
         pathname: '/book/[id]',
         params: {
@@ -529,6 +529,7 @@ function ShelfContent({
         interactionState={interactionState}
         key={key}
         networkImageEnabled={coverActivation.activatedKeys.has(key)}
+        // Selection mode reads component state, so this closure cannot be hoisted.
         onPress={interactionMode === 'select' ? () => toggleSelection(key) : handlePress}
         tileWidth={tileWidth}
       />
@@ -537,7 +538,10 @@ function ShelfContent({
         {...reorderProps}
         interactionState={interactionState}
         key={key}
-        onPress={interactionMode === 'select' ? () => toggleSelection(key) : handlePress}
+        // No book to navigate to, so pressing only ever toggles selection.
+        onPress={() => {
+          if (interactionMode === 'select') toggleSelection(key);
+        }}
         tileWidth={tileWidth}
       />
     );


### PR DESCRIPTION
## What

Three commits on the Android cover pipeline, each measured before/after on a
device rather than reasoned about:

1. **`e60f31d` — cover placeholder cost.** The BlurHash placeholder was a Jetpack
   Compose `ExpoUIView`, so every cover tile in a grid mounted a `ComposeView`
   plus its own composition and `AndroidComposeView` owner. It is now a plain
   `ExpoView` that draws the bitmap itself, with a 256-entry LRU of decoded
   placeholders. A duplicate expo-image BlurHash layer that was drawn *and* then
   covered by that view is gone, the RN `Animated` cross-fade moved to
   expo-image's native `transition`, and the placeholder unmounts once the cover
   is opaque.

   This also fixes a real bug: the native props were named `width`/`height`,
   which collide with React Native's layout style names, so Yoga sized the view
   to the decode dimensions and every placeholder rendered at 112x168px instead
   of the tile's 354x530. They are now `decodeWidth`/`decodeHeight`.

2. **`ce9cddc` — bound the all-novels list window.** Scrolling the infinite grid
   retained RN's default ~21 screens of rows and their cover bitmaps.

3. **`57fb13e` — review pass.** Removes duplicated comments, drops comments that
   narrate the previous implementation, and gates the ranking grid's
   `removeClippedSubviews` to Android to match the four other lists in this app.

## Measurements

OnePlus PLC110, Android 16 (API 36), 144Hz panel, release build made
profileable, image caches dropped before every run, medians of 3-4 alternating
runs per side.

Placeholder work (ranking grid scroll):

| | before | after |
|---|---|---|
| frame p90 / p99 | 25.2ms / 38.7ms | 19.1ms / 29.7ms |
| dropped frames | 21 | 11 |
| GC time in phase | 416ms | 0ms |
| JS thread CPU | 873ms | 463ms |
| `Compose:initializeView` | 68 | 3 |
| draw slices, cold scroll | 1972ms | 1023ms |